### PR TITLE
iptables: use the host's xtables lock, and wait for the lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ COPY pkg/ pkg/
 RUN CGO_ENABLED=0 GO111MODULE=on go build -a -o network-node-manager main.go
 
 # Build image
-FROM alpine:3.11.6
-RUN apk add iptables=1.8.3-r2 ip6tables=1.8.3-r2
+FROM alpine:3.13.3
+RUN apk add --no-cache iptables=1.8.6-r0 ip6tables=1.8.6-r0
 
 WORKDIR /
 COPY --from=builder /workspace/network-node-manager .

--- a/deploy/network-node-manager_iptables.yml
+++ b/deploy/network-node-manager_iptables.yml
@@ -85,6 +85,14 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate

--- a/deploy/network-node-manager_ipvs.yml
+++ b/deploy/network-node-manager_ipvs.yml
@@ -88,6 +88,14 @@ spec:
         securityContext:
           capabilities:
             add: ["NET_ADMIN"]
+        volumeMounts:
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      volumes:
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate


### PR DESCRIPTION
I noticed some odd behaviour when a node is starting afresh and lots of containers are being scheduled: it will often error out and abort with odd iptables error messages. It turns out this is due to not sharing the node's global xtables lock.

Unfortunately it's not as simple as just passing through the lockfile: by default iptables doesn't wait for the lock and instead just returns an error when the lock is held. So this PR also updates `iptables.go` to correctly wait for the lock if it is held.